### PR TITLE
Added proper wrapping for javascript files and removed JQuery 1.8 refere...

### DIFF
--- a/js/open_framework.js
+++ b/js/open_framework.js
@@ -1,115 +1,124 @@
-$(document).ready(function(){
-	
-	// Reset iPhone, iPad, and iPod zoom on orientation change to landscape
-	var mobile_timer = false;
-	if((navigator.userAgent.match(/iPhone/i)) || (navigator.userAgent.match(/iPad/i)) || (navigator.userAgent.match(/iPod/i))) {
-		$('#viewport').attr('content','width=device-width,minimum-scale=1.0,maximum-scale=1.0,initial-scale=1.0');
-		$(window).bind('gesturestart',function () {
-			clearTimeout(mobile_timer);
-			$('#viewport').attr('content','width=device-width,minimum-scale=1.0,maximum-scale=10.0');
-		}).bind('touchend',function () {
-			clearTimeout(mobile_timer);
-			mobile_timer = setTimeout(function () {
+(function ($) {
+
+  Drupal.behaviors.open_framework = {
+    attach: function (context, settings) {
+
+
+			// Reset iPhone, iPad, and iPod zoom on orientation change to landscape
+			var mobile_timer = false;
+			if((navigator.userAgent.match(/iPhone/i)) || (navigator.userAgent.match(/iPad/i)) || (navigator.userAgent.match(/iPod/i))) {
 				$('#viewport').attr('content','width=device-width,minimum-scale=1.0,maximum-scale=1.0,initial-scale=1.0');
-			},1000);
-		});
-	}   
-		
-	// Header Drupal Search Box
-	$('#header [name=search_block_form]').val('Search this site...');
-	$('#header [name=search_block_form]').focus(function () {
-	$('#header [name=search_block_form]').val('');
-	});
-	
-	// Hide border for image links
-	$('a:has(img)').css('border', 'none');
-	
-	// Update CSS classes based on window load
-	$(window).load(function() {
-		var width = $(window).width();
-		
-		if ((width >= 751) && (width < 963)) {
-		$('.two-sidebars #sidebar-first').removeClass('span3');
-		$('.two-sidebars #sidebar-first').addClass('span4');
-		$('.two-sidebars #sidebar-second').removeClass('span3');
-		$('.two-sidebars #sidebar-second').addClass('span12');
-		$('.two-sidebars #content').removeClass('span6');
-		$('.two-sidebars #content').addClass('span8');
-		$('.two-sidebars .region-sidebar-second .block').addClass('span4');
-    	$('.sidebar-first #sidebar-first').removeClass('span3');
-		$('.sidebar-first #sidebar-first').addClass('span4');
-		$('.sidebar-first #content').removeClass('span9');
-		$('.sidebar-first #content').addClass('span8');
-		$('.sidebar-second #sidebar-second').removeClass('span3');
-		$('.sidebar-second #sidebar-second').addClass('span12');
-		$('.sidebar-second #content').removeClass('span9');
-		$('.sidebar-second #content').addClass('span12');
-		$('.sidebar-second .region-sidebar-second .block').addClass('span4');
-		}
+				$(window).bind('gesturestart',function () {
+					clearTimeout(mobile_timer);
+					$('#viewport').attr('content','width=device-width,minimum-scale=1.0,maximum-scale=10.0');
+				}).bind('touchend',function () {
+					clearTimeout(mobile_timer);
+					mobile_timer = setTimeout(function () {
+						$('#viewport').attr('content','width=device-width,minimum-scale=1.0,maximum-scale=1.0,initial-scale=1.0');
+					},1000);
+				});
+			}
 
-		else {
-		$('.two-sidebars #sidebar-first').removeClass('span4');
-		$('.two-sidebars #sidebar-first').addClass('span3');
-		$('.two-sidebars #sidebar-second').removeClass('span12');
-		$('.two-sidebars #sidebar-second').addClass('span3');
-		$('.two-sidebars #content').removeClass('span8');
-		$('.two-sidebars #content').addClass('span6');
-		$('.two-sidebars .region-sidebar-second .block').removeClass('span4');
-    	$('.sidebar-first #sidebar-first').removeClass('span4');
-		$('.sidebar-first #sidebar-first').addClass('span3');
-		$('.sidebar-first #content').removeClass('span8');
-		$('.sidebar-first #content').addClass('span9');
-		$('.sidebar-second #sidebar-second').removeClass('span12');
-		$('.sidebar-second #sidebar-second').addClass('span3');
-		$('.sidebar-second #content').removeClass('span12');
-		$('.sidebar-second #content').addClass('span9');
-		$('.sidebar-second .region-sidebar-second .block').removeClass('span4');
-		}
-	});
-	
-	// Update CSS classes based on window resize
-	$(window).resize(function() {
-		var width = $(window).width();
-		
-		if ((width >= 751) && (width < 963)) {
-		$('.two-sidebars #sidebar-first').removeClass('span3');
-		$('.two-sidebars #sidebar-first').addClass('span4');
-		$('.two-sidebars #sidebar-second').removeClass('span3');
-		$('.two-sidebars #sidebar-second').addClass('span12');
-		$('.two-sidebars #content').removeClass('span6');
-		$('.two-sidebars #content').addClass('span8');
-		$('.two-sidebars .region-sidebar-second .block').addClass('span4');
-    	$('.sidebar-first #sidebar-first').removeClass('span3');
-		$('.sidebar-first #sidebar-first').addClass('span4');
-		$('.sidebar-first #content').removeClass('span9');
-		$('.sidebar-first #content').addClass('span8');
-		$('.sidebar-second #sidebar-second').removeClass('span3');
-		$('.sidebar-second #sidebar-second').addClass('span12');
-		$('.sidebar-second #content').removeClass('span9');
-		$('.sidebar-second #content').addClass('span12');
-		$('.sidebar-second .region-sidebar-second .block').addClass('span4');
-		}
+			// Header Drupal Search Box
+			$('#header [name=search_block_form]').val('Search this site...');
+			$('#header [name=search_block_form]').focus(function () {
+			$('#header [name=search_block_form]').val('');
+			});
 
-		else {
-		$('.two-sidebars #sidebar-first').removeClass('span4');
-		$('.two-sidebars #sidebar-first').addClass('span3');
-		$('.two-sidebars #sidebar-second').removeClass('span12');
-		$('.two-sidebars #sidebar-second').addClass('span3');
-		$('.two-sidebars #content').removeClass('span8');
-		$('.two-sidebars #content').addClass('span6');
-		$('.two-sidebars .region-sidebar-second .block').removeClass('span4');
-    	$('.sidebar-first #sidebar-first').removeClass('span4');
-		$('.sidebar-first #sidebar-first').addClass('span3');
-		$('.sidebar-first #content').removeClass('span8');
-		$('.sidebar-first #content').addClass('span9');
-		$('.sidebar-second #sidebar-second').removeClass('span12');
-		$('.sidebar-second #sidebar-second').addClass('span3');
-		$('.sidebar-second #content').removeClass('span12');
-		$('.sidebar-second #content').addClass('span9');
-		$('.sidebar-second .region-sidebar-second .block').removeClass('span4');
+			// Hide border for image links
+			$('a:has(img)').css('border', 'none');
+
+			// Update CSS classes based on window load
+			$(window).load(function() {
+				var width = $(window).width();
+
+				if ((width >= 751) && (width < 963)) {
+				$('.two-sidebars #sidebar-first').removeClass('span3');
+				$('.two-sidebars #sidebar-first').addClass('span4');
+				$('.two-sidebars #sidebar-second').removeClass('span3');
+				$('.two-sidebars #sidebar-second').addClass('span12');
+				$('.two-sidebars #content').removeClass('span6');
+				$('.two-sidebars #content').addClass('span8');
+				$('.two-sidebars .region-sidebar-second .block').addClass('span4');
+		    	$('.sidebar-first #sidebar-first').removeClass('span3');
+				$('.sidebar-first #sidebar-first').addClass('span4');
+				$('.sidebar-first #content').removeClass('span9');
+				$('.sidebar-first #content').addClass('span8');
+				$('.sidebar-second #sidebar-second').removeClass('span3');
+				$('.sidebar-second #sidebar-second').addClass('span12');
+				$('.sidebar-second #content').removeClass('span9');
+				$('.sidebar-second #content').addClass('span12');
+				$('.sidebar-second .region-sidebar-second .block').addClass('span4');
+				}
+
+				else {
+				$('.two-sidebars #sidebar-first').removeClass('span4');
+				$('.two-sidebars #sidebar-first').addClass('span3');
+				$('.two-sidebars #sidebar-second').removeClass('span12');
+				$('.two-sidebars #sidebar-second').addClass('span3');
+				$('.two-sidebars #content').removeClass('span8');
+				$('.two-sidebars #content').addClass('span6');
+				$('.two-sidebars .region-sidebar-second .block').removeClass('span4');
+		    	$('.sidebar-first #sidebar-first').removeClass('span4');
+				$('.sidebar-first #sidebar-first').addClass('span3');
+				$('.sidebar-first #content').removeClass('span8');
+				$('.sidebar-first #content').addClass('span9');
+				$('.sidebar-second #sidebar-second').removeClass('span12');
+				$('.sidebar-second #sidebar-second').addClass('span3');
+				$('.sidebar-second #content').removeClass('span12');
+				$('.sidebar-second #content').addClass('span9');
+				$('.sidebar-second .region-sidebar-second .block').removeClass('span4');
+				}
+			});
+
+			// Update CSS classes based on window resize
+			$(window).resize(function() {
+				var width = $(window).width();
+
+				if ((width >= 751) && (width < 963)) {
+				$('.two-sidebars #sidebar-first').removeClass('span3');
+				$('.two-sidebars #sidebar-first').addClass('span4');
+				$('.two-sidebars #sidebar-second').removeClass('span3');
+				$('.two-sidebars #sidebar-second').addClass('span12');
+				$('.two-sidebars #content').removeClass('span6');
+				$('.two-sidebars #content').addClass('span8');
+				$('.two-sidebars .region-sidebar-second .block').addClass('span4');
+		    	$('.sidebar-first #sidebar-first').removeClass('span3');
+				$('.sidebar-first #sidebar-first').addClass('span4');
+				$('.sidebar-first #content').removeClass('span9');
+				$('.sidebar-first #content').addClass('span8');
+				$('.sidebar-second #sidebar-second').removeClass('span3');
+				$('.sidebar-second #sidebar-second').addClass('span12');
+				$('.sidebar-second #content').removeClass('span9');
+				$('.sidebar-second #content').addClass('span12');
+				$('.sidebar-second .region-sidebar-second .block').addClass('span4');
+				}
+
+				else {
+				$('.two-sidebars #sidebar-first').removeClass('span4');
+				$('.two-sidebars #sidebar-first').addClass('span3');
+				$('.two-sidebars #sidebar-second').removeClass('span12');
+				$('.two-sidebars #sidebar-second').addClass('span3');
+				$('.two-sidebars #content').removeClass('span8');
+				$('.two-sidebars #content').addClass('span6');
+				$('.two-sidebars .region-sidebar-second .block').removeClass('span4');
+		    	$('.sidebar-first #sidebar-first').removeClass('span4');
+				$('.sidebar-first #sidebar-first').addClass('span3');
+				$('.sidebar-first #content').removeClass('span8');
+				$('.sidebar-first #content').addClass('span9');
+				$('.sidebar-second #sidebar-second').removeClass('span12');
+				$('.sidebar-second #sidebar-second').addClass('span3');
+				$('.sidebar-second #content').removeClass('span12');
+				$('.sidebar-second #content').addClass('span9');
+				$('.sidebar-second .region-sidebar-second .block').removeClass('span4');
+				}
+			});
+
 		}
-	});
-});
+	}
+}(jQuery));
+
+
 
 // Hide Address Bar in Mobile View
 addEventListener("load", function() { setTimeout(hideURLbar, 0); }, false);

--- a/js/script.js
+++ b/js/script.js
@@ -1,18 +1,24 @@
-$(document).ready(function(){
+(function ($) {
 
-	// Bootstrap Dropdown Menu
-	$('#main-menu ul').addClass('nav');
-	$('#main-menu ul').removeClass('menu');
-	$('#main-menu ul ul').removeClass('nav');
-	$('#main-menu ul li.expanded').addClass('dropdown');
-	$('#main-menu ul li.expanded a').addClass('dropdown-toggle');
-	// $('#main-menu ul li.expanded a').attr('data-toggle', 'dropdown');
-	$('#main-menu ul li.expanded ul').addClass('dropdown-menu');
-	$('#main-menu ul.dropdown-menu li').removeClass('active');
-	$('#main-menu ul li').removeClass('expanded collapsed leaf');
-	$('#main-menu ul li:has(.active)').addClass('active');
-	$('#main-menu ul.nav > li > a.dropdown-toggle').append(' <b class="caret"></b>');
-});
+  Drupal.behaviors.open_framework = {
+    attach: function (context, settings) {
+
+			// Bootstrap Dropdown Menu
+			$('#main-menu ul').addClass('nav');
+			$('#main-menu ul').removeClass('menu');
+			$('#main-menu ul ul').removeClass('nav');
+			$('#main-menu ul li.expanded').addClass('dropdown');
+			$('#main-menu ul li.expanded a').addClass('dropdown-toggle');
+			// $('#main-menu ul li.expanded a').attr('data-toggle', 'dropdown');
+			$('#main-menu ul li.expanded ul').addClass('dropdown-menu');
+			$('#main-menu ul.dropdown-menu li').removeClass('active');
+			$('#main-menu ul li').removeClass('expanded collapsed leaf');
+			$('#main-menu ul li:has(.active)').addClass('active');
+			$('#main-menu ul.nav > li > a.dropdown-toggle').append(' <b class="caret"></b>');
+
+		}
+	}
+}(jQuery));
 
 
 

--- a/open_framework.info
+++ b/open_framework.info
@@ -6,7 +6,6 @@ version = 2.0
 stylesheets[all][] = bootstrap/css/bootstrap.min.css
 stylesheets[all][] = bootstrap/css/bootstrap-responsive.min.css
 stylesheets[all][] = css/open_framework.css
-scripts[] = js/jquery-1.8.1.min.js
 scripts[] = bootstrap/js/bootstrap.min.js
 scripts[] = js/open_framework.js
 scripts[] = js/script.js


### PR DESCRIPTION
Hi Brian,

we just met at BADcamp and I said I would send over some fixes. My first one here removes the JQuery 1.8.1 reference in the .info file. This doesn't now interfere any more with the JQuery Update module. I set it to 1.8 and it works fine.
I had to change the wrapping in your javascript files for proper Drupal wrapping.

My next move is to put proper HTML tags.

Cheers,
Johannes
