### PR TITLE
Updated implementation of theme_status_messages to D7 version

### DIFF
--- a/template.php
+++ b/template.php
@@ -149,17 +149,24 @@ function open_framework_get_span($block_count, $block_id, $count_sidebars) {
 }
 
 /* Status Messages (Error, Status, Alert) */
-function open_framework_status_messages($display = NULL) {
+function open_framework_status_messages($variables) {
+  $display = $variables['display'];
   $output = '';
+
+  $status_heading = array(
+    'status' => t('Status message'), 
+    'error' => t('Error message'), 
+    'warning' => t('Warning message'),
+  );
   foreach (drupal_get_messages($display) as $type => $messages) {
-if ($type == "error") {$alert = 'alert alert-error';}
-   elseif ($type == "status") {$alert = 'alert alert-success';}
-    else {$alert = 'alert';}
-    $output .= "<div class=\"messages $type " . $alert . " \">\n";
+    $output .= "<div class=\"messages $type\">\n";
+    if (!empty($status_heading[$type])) {
+      $output .= '<h2 class="element-invisible">' . $status_heading[$type] . "</h2>\n";
+    }
     if (count($messages) > 1) {
       $output .= " <ul>\n";
       foreach ($messages as $message) {
-        $output .= ' <li>'. $message ."</li>\n";
+        $output .= '  <li>' . $message . "</li>\n";
       }
       $output .= " </ul>\n";
     }


### PR DESCRIPTION
Drupal messages were not appearing; likely this is due to the code used for the implementation of theme_status_messages was D6 code and not D7 code. http://api.drupal.org/api/drupal/includes!theme.inc/function/theme_status_messages/7 and http://api.drupal.org/api/drupal/includes!theme.inc/function/theme_status_messages/6
