### PR TITLE
Streamline javascript

### DIFF
--- a/js/open_framework.js
+++ b/js/open_framework.js
@@ -1,43 +1,48 @@
 (function ($) {
-  Drupal.behaviors.open_framework = {
-    attach: function (context, settings) {
-			// Reset iPhone, iPad, and iPod zoom on orientation change to landscape
-			var mobile_timer = false;
-			if((navigator.userAgent.match(/iPhone/i)) || (navigator.userAgent.match(/iPad/i)) || (navigator.userAgent.match(/iPod/i))) {
-				$('#viewport').attr('content','width=device-width,minimum-scale=1.0,maximum-scale=1.0,initial-scale=1.0');
-				$(window).bind('gesturestart',function () {
-					clearTimeout(mobile_timer);
-					$('#viewport').attr('content','width=device-width,minimum-scale=1.0,maximum-scale=10.0');
-				}).bind('touchend',function () {
-					clearTimeout(mobile_timer);
-					mobile_timer = setTimeout(function () {
-						$('#viewport').attr('content','width=device-width,minimum-scale=1.0,maximum-scale=1.0,initial-scale=1.0');
-					},1000);
-				});
-			}
-			// Header Drupal Search Box
-			$('#header [name=search_block_form]').val('Search this site...');
-			$('#header [name=search_block_form]').focus(function () {
-			$('#header [name=search_block_form]').val('');
-			});
-			// Hide border for image links
-			$('a:has(img)').css('border', 'none');
-		}
-	}
-}(jQuery));
+
+Drupal.behaviors.open_framework = {
+  attach: function (context, settings) {
+    // Reset iPhone, iPad, and iPod zoom on orientation change to landscape
+    var mobile_timer = false;
+    if ((navigator.userAgent.match(/iPhone/i)) || (navigator.userAgent.match(/iPad/i)) || (navigator.userAgent.match(/iPod/i))) {
+      $('#viewport').attr('content', 'width=device-width,minimum-scale=1.0,maximum-scale=1.0,initial-scale=1.0');
+      $(window)
+        .bind('gesturestart', function () {
+          clearTimeout(mobile_timer);
+          $('#viewport').attr('content', 'width=device-width,minimum-scale=1.0,maximum-scale=10.0');
+        })
+        .bind('touchend', function () {
+          clearTimeout(mobile_timer);
+          mobile_timer = setTimeout(function () {
+            $('#viewport').attr('content', 'width=device-width,minimum-scale=1.0,maximum-scale=1.0,initial-scale=1.0');
+          }, 1000);
+        });
+    }
+    // Header Drupal Search Box
+    $('#header [name=search_block_form]')
+      .val('Search this site...')
+      .focus(function () {
+        $(this).val('');
+      });
+    // Hide border for image links
+    $('a:has(img)').css('border', 'none');
+  }
+}
+
+})(jQuery);
 
 //Add legacy IE addEventListener support (http://msdn.microsoft.com/en-us/library/ms536343%28VS.85%29.aspx#1)
 if (!window.addEventListener) {
-    window.addEventListener = function (type, listener, useCapture) {
-        attachEvent('on' + type, function() { listener(event) });
-    }
+  window.addEventListener = function (type, listener, useCapture) {
+    attachEvent('on' + type, function() { listener(event) });
+  }
 }
 //end legacy support addition
 
 // Hide Address Bar in Mobile View
 addEventListener("load", function() { setTimeout(hideURLbar, 0); }, false);
-	function hideURLbar(){
-		if (window.pageYOffset < 1) {
-		window.scrollTo(0, 1);
-	}
+function hideURLbar(){
+  if (window.pageYOffset < 1) {
+    window.scrollTo(0, 1);
+  }
 }

--- a/js/override.js
+++ b/js/override.js
@@ -1,86 +1,133 @@
 (function ($) {
 
-  Drupal.behaviors.open_framework = {
-    attach: function (context, settings) {
-		
-			// Bootstrap dropdown menu in top nav bar
-			$('nav ul > li:has(.active)').addClass('active');
-			$('nav ul > li:has(ul .active)').removeClass('active');			
-	        $('nav ul > li > ul > li:has(.active)').removeClass('active');	
-			$('nav ul ul a').removeAttr('data-toggle','data-target');
-			
-			// Bootstrap dropdown menu in secondary menu
-			$('#secondary-menu ul > li:has(.active)').addClass('active');
-			$('#secondary-menu ul > li:has(ul .active)').removeClass('active');			
-	        $('#secondary-menu ul > li > ul > li:has(.active)').removeClass('active');	
-			$('#secondary-menu ul ul a').removeAttr('data-toggle','data-target');
-			
-			// Turn off Bootstrap dropdown data attributes in sidebars
-			$('#sidebar-first a').removeAttr('data-toggle','data-target');
-			$('#sidebar-first ul').removeClass('dropdown-menu','dropdown-submenu');
-			$('#sidebar-second a').removeAttr('data-toggle','data-target');
-			$('#sidebar-second ul').removeClass('dropdown-menu','dropdown-submenu');
-			
-			// Set up theme specific responsive behaviors
-			function responsive_behaviors () {
-				var width = $(window).width();
-				
-				if (width < 751) {
-				$('nav li li.expanded').removeClass('dropdown-submenu');
-				$('nav ul ul ul').removeClass('dropdown-menu');
-				}
-				
-				else {
-				$('nav li li.expanded').addClass('dropdown-submenu');
-				$('nav ul ul ul').addClass('dropdown-menu');
-				}
-				
-				if ((width >= 751) && (width < 963)) {
-				$('.two-sidebars #sidebar-first').removeClass('span3');
-				$('.two-sidebars #sidebar-first').addClass('span4');
-				$('.two-sidebars #sidebar-second').removeClass('span3');
-				$('.two-sidebars #sidebar-second').addClass('span12');
-				$('.two-sidebars #content').removeClass('span6');
-				$('.two-sidebars #content').addClass('span8');
-				$('.two-sidebars .region-sidebar-second .block').addClass('span4');
-		    	$('.sidebar-first #sidebar-first').removeClass('span3');
-				$('.sidebar-first #sidebar-first').addClass('span4');
-				$('.sidebar-first #content').removeClass('span9');
-				$('.sidebar-first #content').addClass('span8');
-				$('.sidebar-second #sidebar-second').removeClass('span3');
-				$('.sidebar-second #sidebar-second').addClass('span12');
-				$('.sidebar-second #content').removeClass('span9');
-				$('.sidebar-second #content').addClass('span12');
-				$('.sidebar-second .region-sidebar-second .block').addClass('span4');
-				}
+Drupal.behaviors.open_framework_override = {
+  attach: function (context, settings) {
 
-				else {
-				$('.two-sidebars #sidebar-first').removeClass('span4');
-				$('.two-sidebars #sidebar-first').addClass('span3');
-				$('.two-sidebars #sidebar-second').removeClass('span12');
-				$('.two-sidebars #sidebar-second').addClass('span3');
-				$('.two-sidebars #content').removeClass('span8');
-				$('.two-sidebars #content').addClass('span6');
-				$('.two-sidebars .region-sidebar-second .block').removeClass('span4');
-		    	$('.sidebar-first #sidebar-first').removeClass('span4');
-				$('.sidebar-first #sidebar-first').addClass('span3');
-				$('.sidebar-first #content').removeClass('span8');
-				$('.sidebar-first #content').addClass('span9');
-				$('.sidebar-second #sidebar-second').removeClass('span12');
-				$('.sidebar-second #sidebar-second').addClass('span3');
-				$('.sidebar-second #content').removeClass('span12');
-				$('.sidebar-second #content').addClass('span9');
-				$('.sidebar-second .region-sidebar-second .block').removeClass('span4');
-				}
-			}
-			
-			// Update CSS classes based on window load and resize
-			$(window).load(responsive_behaviors);
-			$(window).resize(responsive_behaviors);
+    // Bootstrap dropdown menu in top nav bar
+    // Bootstrap dropdown menu in secondary menu
+    $('nav ul, #secondary-menu ul')
+      .children('li')
+        .filter(':has(.active)')
+          .addClass('active')
+        .end()
+        .filter(':has(ul .active)')
+          .removeClass('active')
+        .end()
+      .end()
+      .find('ul a')
+        .removeAttr('data-toggle')
+        .removeAttr('data-target')
 
-		}
-	}
-}(jQuery));
+    // Turn off Bootstrap dropdown data attributes in sidebars
+    $('#sidebar-first, #sidebar-second')
+      .find('a')
+        .removeAttr('data-toggle')
+        .removeAttr('data-target')
+      .end()
+      .find('ul')
+        .removeClass('dropdown-menu', 'dropdown-submenu')
+      .end();
 
+    // Set up theme specific responsive behaviors
+    function responsive_behaviors () {
+      var width = $(window).width();
 
+      if (width < 751) {
+        $('nav li li.expanded').removeClass('dropdown-submenu');
+        $('nav ul ul ul').removeClass('dropdown-menu');
+      }
 
+      else {
+        $('nav li li.expanded').addClass('dropdown-submenu');
+        $('nav ul ul ul').addClass('dropdown-menu');
+      }
+
+      if ((width >= 751) && (width < 963)) {
+        $('.two-sidebars')
+          .find('#sidebar-first')
+            .removeClass('span3')
+            .addClass('span4')
+          .end()
+          .find('#sidebar-second')
+            .removeClass('span3')
+            .addClass('span12')
+          .end()
+          .find('#content')
+            .removeClass('span6')
+            .addClass('span8')
+          .end()
+          .find('.region-sidebar-second .block')
+            .addClass('span4')
+          .end();
+        $('.sidebar-first')
+          .find('#sidebar-first')
+            .removeClass('span3')
+            .addClass('span4')
+          .end()
+          .find('#content')
+            .removeClass('span9')
+            .addClass('span8')
+          .end();
+        $('.sidebar-second')
+          .find('#sidebar-second')
+            .removeClass('span3')
+            .addClass('span12')
+          .end()
+          .find('#content')
+            .removeClass('span9')
+            .addClass('span12')
+          .end()
+          .find('.region-sidebar-second .block')
+            .addClass('span4')
+          .end();
+      }
+
+      else {
+        $('.two-sidebars')
+          .find('#sidebar-first')
+            .removeClass('span4')
+            .addClass('span3')
+          .end()
+          .find('#sidebar-second')
+            .removeClass('span12')
+            .addClass('span3')
+          .end()
+          .find('#content')
+            .removeClass('span8')
+            .addClass('span6')
+          .end()
+          .find('.two-sidebars .region-sidebar-second .block')
+            .removeClass('span4')
+          .end();
+        $('.sidebar-first')
+          .find('#sidebar-first')
+            .removeClass('span4')
+            .addClass('span3')
+          .end()
+          .find('#content')
+            .removeClass('span8')
+            .addClass('span9')
+          .end();
+        $('.sidebar-second')
+          .find('#sidebar-second')
+            .removeClass('span12')
+            .addClass('span3')
+          .end()
+          .find('#content')
+            .removeClass('span12')
+            .addClass('span9')
+          .end()
+          .find('.sidebar-second .region-sidebar-second .block')
+            .removeClass('span4')
+          .end();
+      }
+    }
+
+    // Update CSS classes based on window load and resize
+    $(window)
+      .load(responsive_behaviors)
+      .resize(responsive_behaviors);
+  }
+}
+
+})(jQuery);


### PR DESCRIPTION
In addition to indentation issues, open_framework.js and override.js can never run at the same time, since they share an identically named behavior.

Also, .removeAttr() only takes one parameter, and that code was silently failing.

All of the class switching code was performing new selections every time, I rewrote it to only run once, as needed.
