### PR TITLE
Update open_framework.css

### DIFF
--- a/css/open_framework.css
+++ b/css/open_framework.css
@@ -809,6 +809,10 @@ ul.primary{
 		float:left;
 	}
 	
+	.region-navigation .block.pull-right {
+                float:right;
+        }
+	
 	.content-row2 [class*="span"]:nth-child(2n+1), .content-row3 [class*="span"]:nth-child(3n+1), .content-row4 [class*="span"]:nth-child(4n+1){
 		clear: both;
 		margin-left:0;	


### PR DESCRIPTION
Fixes GH-117 by restoring Bootstrap's pull-right class float:right behavior on blocks in the navigation region
