### PR TITLE
Fix nav-search to .nav-search in open_framework.css

### DIFF
--- a/css/open_framework.css
+++ b/css/open_framework.css
@@ -246,7 +246,7 @@ hr {
 	margin:0;
 	padding:0;
 }
-nav-search .form-item,
+.nav-search .form-item,
 #header-search .form-item {
 	margin:0;
 }


### PR DESCRIPTION
This pull request fixes a typo in open_framework.css, changing the selector `nav-search .form-item` to `.nav-search .form-item`.
