### PR TITLE
Fix typo in breadcrumb_classes setting

### DIFF
--- a/template.php
+++ b/template.php
@@ -544,7 +544,7 @@ function open_framework_breadcrumb(&$variables) {
   $output = '';
   $breadcrumb = $variables['breadcrumb'];
   $show_breadcrumb = theme_get_setting('breadcrumb_classes');
-  if ($show_breadcrumb == 'show-breadcrumb ') {
+  if ($show_breadcrumb == 'show-breadcrumb') {
     if (!empty($breadcrumb)) {
       // Provide a navigational heading to give context for breadcrumb links to
       // screen-reader users. Make the heading invisible with .element-invisible.

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -45,7 +45,7 @@ function open_framework_form_system_theme_settings_alter(&$form, &$form_state) {
     '#default_value' => theme_get_setting('breadcrumb_classes'),
     '#options'       => array(
       '' => t('Hide breadcrumbs - <strong><em>Default</em></strong>'),
-	  'show-breadcrumb ' => t('Show breadcrumbs'),
+	  'show-breadcrumb' => t('Show breadcrumbs'),
     ),
   );
       


### PR DESCRIPTION
This pull-request will sanitize the option value accepted by the theme setting breadcrumb_classes by removing the trailing space.

I know this is **not backwards compatibly**, but please think about adjusting your last change to a more sane option-value. Maybe one could run a migration on updating the theme, but I am not that much into maintaining Drupal Modules. If you can lead the way, I am happy to integrate a simple migration that fixes existing database values as well.

The two commits fix the theme settings admin pane (`theme-settings.php`) and the interpretation of the value inside `template.php`

Best regards and keep up the good work,

Lennart
