### PR TITLE
Added bean template from bean 7.x-1.11

### DIFF
--- a/templates/bean.tpl.php
+++ b/templates/bean.tpl.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @file
+ * Default theme implementation for beans.
+ *
+ * Available variables:
+ * - $content: An array of comment items. Use render($content) to print them all, or
+ *   print a subset such as render($content['field_example']). Use
+ *   hide($content['field_example']) to temporarily suppress the printing of a
+ *   given element.
+ * - $title: The (sanitized) entity label.
+ * - $url: Direct url of the current entity if specified.
+ * - $page: Flag for the full page state.
+ * - $classes: String of classes that can be used to style contextually through
+ *   CSS. It can be manipulated through the variable $classes_array from
+ *   preprocess functions. By default the following classes are available, where
+ *   the parts enclosed by {} are replaced by the appropriate values:
+ *   - entity-{ENTITY_TYPE}
+ *   - {ENTITY_TYPE}-{BUNDLE}
+ *
+ * Other variables:
+ * - $classes_array: Array of html class attribute values. It is flattened
+ *   into a string within the variable $classes.
+ *
+ * @see template_preprocess()
+ * @see template_preprocess_entity()
+ * @see template_process()
+ */
+?>
+<div class="<?php print $classes; ?> clearfix"<?php print $attributes; ?>>
+
+  <div class="content"<?php print $content_attributes; ?>>
+    <?php
+    print render($content);
+    ?>
+  </div>
+</div>

--- a/templates/bean.tpl.php
+++ b/templates/bean.tpl.php
@@ -1,11 +1,12 @@
 <?php
+
 /**
  * @file
  * Default theme implementation for beans.
  *
  * Available variables:
- * - $content: An array of comment items. Use render($content) to print them all, or
- *   print a subset such as render($content['field_example']). Use
+ * - $content: An array of comment items. Use render($content) to print them all,
+ *   or print a subset such as render($content['field_example']). Use
  *   hide($content['field_example']) to temporarily suppress the printing of a
  *   given element.
  * - $title: The (sanitized) entity label.


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removes the duplicate block labels

# Needed By (Date)
- asap

# Urgency
- High

# Steps to Test

1. ensure you have the latest bean module `7.x-1.13`
1. create a bean and display it on page
1. validate the double block titles
1. checkout this branch and clear cache
1. reload the page and validate only 1 block title

# Affected Projects or Products
- all people and sites on ACSF


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)