### PR TITLE
Allow jquery to be updated on /admin pages

### DIFF
--- a/template.php
+++ b/template.php
@@ -43,7 +43,7 @@ function open_framework_preprocess_html(&$vars) {
 
 function open_framework_js_alter(&$javascript) {
   // Update jquery version for non-administration pages
-  if (arg(0) != 'admin' && arg(0) != 'panels' && arg(0) != 'ctools'  && !(module_exists('jquery_update'))) {
+  if (arg(0) != 'panels' && arg(0) != 'ctools'  && !(module_exists('jquery_update'))) {
     $jquery_file = drupal_get_path('theme', 'open_framework') . '/js/jquery-1.9.1.min.js';
     $jquery_version = '1.9.1';
     $migrate_file = drupal_get_path('theme', 'open_framework') . '/js/jquery-migrate-1.2.1.min.js';


### PR DESCRIPTION
There is javascript in this theme that is reliant on jquery version 1.9 and when jquery defaults to core (1.4) it breaks. 

The bigger issue is that there is a dependency on jquery 1.9 that is not being enforced in this theme.

Steps to reproduce:
1. Enable this theme as admin theme
2. Create a new view
3. View console log for issues on missing `.on` command